### PR TITLE
Add compatibility with recent eth_abi.encode() method, fix binary PrivateKey to string conversion, automatically convert numerical fields to int when given as strings 

### DIFF
--- a/eip712/__init__.py
+++ b/eip712/__init__.py
@@ -26,8 +26,6 @@ import re
 from coincurve import PrivateKey
 import eth_abi
 from eth_utils import keccak, big_endian_to_int
-from eth_account import Account
-
 
 def encode_data(primary_type, data, types):
     """

--- a/eip712/__init__.py
+++ b/eip712/__init__.py
@@ -68,7 +68,7 @@ def encode_data(primary_type, data, types):
     for field in types[primary_type]:
         typ, val = _encode_field(field['name'], field['type'], data[field['name']])
         encoded_types.append(typ)
-        if re.search(r'^u?int(\d+)$', typ) and isinstance(val, str):
+        if re.search(r'^u?int\d+$', typ) and isinstance(val, str):
             val = int(val)
         encoded_values.append(val)
 


### PR DESCRIPTION
-  eth_abi.encode_abi() method was removed in eth_abi version 4.0.0. Changed syntax to a more recent eth_abi.encode() method.
- there was a bug https://github.com/jvinet/eip712/blob/b3cad03059b81fe6e33a5a7b2055c2ae49251b49/eip712/__init__.py#L147 when converting binary PrivateKey into a hex string.
- Often payload numeric field values are given as strings. Added explicit string to int conversion for numerical field types in encode_data().